### PR TITLE
Fix the massive, obvious security flaw

### DIFF
--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -1,0 +1,26 @@
+pragma solidity 0.5;
+
+contract Owned {
+    address private owner;
+
+    event LogOwnerChanged(address indexed previousOwner, address newOwner);
+
+    constructor() public {
+        owner = msg.sender;
+    }
+
+    function getOwner() public view returns(address) {
+        return owner;
+    }
+
+    function changeOwner(address newOwner) public {
+        require(msg.sender == owner, "Must be contract owner");
+        emit LogOwnerChanged(owner, newOwner);
+        owner = newOwner;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Must be contract owner");
+        _;
+    }
+}

--- a/contracts/Pausable.sol
+++ b/contracts/Pausable.sol
@@ -1,0 +1,29 @@
+pragma solidity 0.5;
+
+import "./Owned.sol";
+
+contract Pausable is Owned {
+    bool private isRunning;
+
+    event LogContractPaused(address sender);
+    event LogContractResumed(address sender);
+
+    constructor() public {
+        isRunning = true;
+    }
+
+    modifier onlyIfRunning() {
+        require(isRunning, "Contract must be running");
+        _;
+    }
+
+    function pauseContract() public onlyOwner {
+        isRunning = false;
+        emit LogContractPaused(msg.sender);
+    }
+
+    function resumeContract() public onlyOwner {
+        isRunning = true;
+        emit LogContractResumed(msg.sender);
+    }
+}


### PR DESCRIPTION
Changes:
- Owned and Pausable contracts moved to their own files
- Add "exchanger" address to deposit() and verify on withdraw()
- deposit() now takes the already-created hash of the two passwords

Outstanding Problems/Next Steps:
- Password hash could be reused, which would allow exchanger to withdraw money without Bob
- Password hash could be changed by Alice, rendering Bob's password useless
- If Bob's password is intercepted/stolen, the stealer can go to the exchanger to withdraw the money (no verification of Bob's identity)
- I believe these will be fixed with the stretch goals: 1. turning contract into utility (mapping structure where balance is indexed by password hash -- allows different recipients/exchangers, keeps balance linked with deposit hash) and 2. replacing the exchanger's password with the recipient's address (exchanger could then verify that recipient is actual owner of the address before withdrawing).